### PR TITLE
Lint fix

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,8 @@
   ],
   "env": {
     "es6": true,
-    "jest": true
+    "jest": true,
+    "browser": true
   },
   "settings": {
     "react": {
@@ -137,8 +138,5 @@
     "react/prop-types": "off",
     "react/jsx-key": "error"
   },
-  "globals": {
-  "fetch": false
-}
 
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "eslint:recommended",
-    "plugin:react/recommended"
-  ],
+  "extends": ["eslint:recommended", "plugin:react/recommended"],
   "parserOptions": {
     "ecmaVersion": 2020,
     "ecmaFeatures": {
@@ -10,9 +7,7 @@
     },
     "sourceType": "module"
   },
-  "plugins": [
-    "react"
-  ],
+  "plugins": ["react"],
   "env": {
     "es6": true,
     "jest": true,
@@ -85,10 +80,7 @@
         "variables": true
       }
     ],
-    "curly": [
-      "error",
-      "multi-line"
-    ],
+    "curly": ["error", "multi-line"],
     "eqeqeq": [
       "error",
       "always",
@@ -104,10 +96,7 @@
         "allowTemplateLiterals": true
       }
     ],
-    "jsx-quotes": [
-      "error",
-      "prefer-double"
-    ],
+    "jsx-quotes": ["error", "prefer-double"],
     "react/jsx-boolean-value": [
       "error",
       "never",
@@ -115,13 +104,8 @@
         "always": []
       }
     ],
-    "react/no-deprecated": [
-      "error"
-    ],
-    "react/prefer-es6-class": [
-      "error",
-      "always"
-    ],
+    "react/no-deprecated": ["error"],
+    "react/prefer-es6-class": ["error", "always"],
     "react/prefer-stateless-function": [
       "warn",
       {
@@ -137,6 +121,5 @@
     "react/react-in-jsx-scope": "off",
     "react/prop-types": "off",
     "react/jsx-key": "error"
-  },
-
+  }
 }


### PR DESCRIPTION
Better way to ignore the eslint warning for fetch. Following Prof. Andrews advice, added browser to the environments and removed fetch from globals.