### PR TITLE
fix styling issue at top of page

### DIFF
--- a/src/pages/dj.js
+++ b/src/pages/dj.js
@@ -1,7 +1,4 @@
-
-import Head from "next/head";
 import DjEntry from "../components/DjEntry";
-import styles from "../styles/Home.module.css";
 import Grid from "@material-ui/core/Grid";
 import CircularProgress from "@material-ui/core/CircularProgress";
 import WarningIcon from "@material-ui/icons/Warning";
@@ -21,22 +18,14 @@ export default function DJ() {
   }, [session])
   
     return (
-      <div className={styles.container}>
-      <Head>
-        <title>WRMC</title>
-        <link rel="icon" href="/favicon.ico" />
-        <img
-          src="https://wrmc.middlebury.edu/wp-content/themes/wrmc/images/logo_large.png"
-          width="400"
-          alt="WRMC 91.1 FM Middlebury College Radio 91.1 FM"
-        />
-      </Head>
-      {!session && <Grid>
-      <h3 color="red"><WarningIcon color="secondary"/> ACCESS DENIED</h3>
-      <h3>Redirecting <CircularProgress color="secondary" /></h3>
-      </Grid>}
-      {session && <DjEntry />}
-    </div>
-    
-)}
+      <div>
+        {session && <DjEntry />}
+        {!session && <Grid>
+        <h3 color="red"><WarningIcon color="secondary"/> ACCESS DENIED</h3>
+        <h3>Redirecting <CircularProgress color="secondary" /></h3>
+        </Grid>}
+      </div>
+    )
+  
+}
 


### PR DESCRIPTION
Because of the confusion between dj.js and DjEntry.js, we had extra styling in dj.js that was messing up the blue bar at the top of the page. I deleted the styling from dj.js and things seem to be back to normal now.